### PR TITLE
fix transaction link in sendTransaction example

### DIFF
--- a/example/src/main/java/io/outblock/fcl/example/MainActivity.kt
+++ b/example/src/main/java/io/outblock/fcl/example/MainActivity.kt
@@ -140,7 +140,7 @@ class MainActivity : AppCompatActivity() {
                         txidView.text = result.value
                         txidLayout.visibility = View.VISIBLE
                         viewOnFlowScanView.setOnClickListener {
-                            "https://${if (Fcl.isMainnet()) "" else "testnet."}flowscan.org/transaction/$result".openInSystemBrowser(
+                            "https://${if (Fcl.isMainnet()) "" else "testnet."}flowscan.org/transaction/${result.value}".openInSystemBrowser(
                                 this@MainActivity
                             )
                         }


### PR DESCRIPTION
Currently, after sending transaction, incorrect flowscan link is opening
https://testnet.flowscan.org/transaction/Success(value=a384a2f57dafb169ca0c654e4fd4f67f3ada307c5d807cf7defeb4ef8cf7f41f)
`"https://${if (Fcl.isMainnet()) "" else "testnet."}flowscan.org/transaction/$result"`

`$result` is FclResult, use ${result.value}